### PR TITLE
enable wireless display / miracast

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2384,7 +2384,7 @@
          * The remote submix module "audio.r_submix.default" must be installed on the device.
          * The device must be provisioned with HDCP keys (for protected content).
     -->
-    <bool name="config_enableWifiDisplay">false</bool>
+    <bool name="config_enableWifiDisplay">true</bool>
 
     <!-- When true, local displays that do not contain any of their own content will automatically
          mirror the content of the default display. -->


### PR DESCRIPTION
As in https://review.lineageos.org/c/LineageOS/android_device_google_marlin/+/224379
After enabling it in frameworks/av, as in 
https://review.lineageos.org/c/LineageOS/android_frameworks_av/+/238928 and https://review.lineageos.org/c/LineageOS/android_frameworks_av/+/238927